### PR TITLE
Fix Elixir Example Page

### DIFF
--- a/api/contentlayer.config.ts
+++ b/api/contentlayer.config.ts
@@ -58,7 +58,7 @@ export const Example = defineDocumentType(() => ({
       type: "list",
       of: {
         type: "enum",
-        options: ["ts", "js", "rs", "go", "py", "java", "rb"],
+        options: ["ts", "js", "rs", "go", "py", "java", "rb", "elixir"],
       },
       required: true,
     },

--- a/examples/elixir-with-redis/README.md
+++ b/examples/elixir-with-redis/README.md
@@ -19,7 +19,7 @@ author: "CahidArda"
 
 A sample Phoneix app deployed on Fly which uses Redis to store results of requests to an external API.
 
-See the [tutorial](https://upstash.com/docs/redis/tutorials/elixir_with_redis) for details.
+See the [tutorial](https://upstash.com/docs/redis/quickstarts/elixir) for details.
 
 ### Learn More
 


### PR DESCRIPTION
Fixing [the elixir example page](https://upstash.com/examples/elixirwithredis):
- Link is not correct. It still points to the original URL but tutorial was moved to quickstarts.
- Languages doesn't show Elixir. I believe it's because elixir is not available as an option in the configs.