### PR TITLE
Use fromEnv or KV env vars in redis templates

### DIFF
--- a/examples/nextjs-with-redis/src/app/api/increment/route.ts
+++ b/examples/nextjs-with-redis/src/app/api/increment/route.ts
@@ -2,10 +2,7 @@ import { Redis } from '@upstash/redis';
 import { NextResponse } from 'next/server';
 
 // Initialize Redis
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL || '',
-  token: process.env.UPSTASH_REDIS_REST_TOKEN || '',
-});
+const redis = Redis.fromEnv()
 
 export const GET = async () => {
   const identifier = 'api_call_counter';

--- a/examples/nuxt-with-redis/server/api/increment.ts
+++ b/examples/nuxt-with-redis/server/api/increment.ts
@@ -2,10 +2,7 @@ import { defineEventHandler } from "h3";
 import { Redis } from "@upstash/redis";
 
 // Initialize Redis
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL || "",
-  token: process.env.UPSTASH_REDIS_REST_TOKEN || ""
-});
+const redis = Redis.fromEnv()
 
 export default defineEventHandler(async () => {
   const identifier = "api_call_counter";

--- a/examples/sveltekit-with-redis/.env.example
+++ b/examples/sveltekit-with-redis/.env.example
@@ -1,2 +1,10 @@
+# You must configure one of the following sets:
+# - Both UPSTASH_REDIS_REST_URL & UPSTASH_REDIS_REST_TOKEN
+#   or
+# - Both KV_REST_API_URL & KV_REST_API_TOKEN
+
 UPSTASH_REDIS_REST_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
+
+KV_REST_API_URL=""
+KV_REST_API_TOKEN=""

--- a/examples/sveltekit-with-redis/src/routes/api/increment/+server.ts
+++ b/examples/sveltekit-with-redis/src/routes/api/increment/+server.ts
@@ -1,11 +1,11 @@
-import { UPSTASH_REDIS_REST_TOKEN, UPSTASH_REDIS_REST_URL } from "$env/static/private";
+import * as env from "$env/static/private";
 import { json } from '@sveltejs/kit';
 import { Redis } from '@upstash/redis';
 
 // Initialize Redis
 const redis = new Redis({
-  url: UPSTASH_REDIS_REST_URL || "",
-  token: UPSTASH_REDIS_REST_TOKEN || ""
+  url: env.UPSTASH_REDIS_REST_URL || env.KV_REST_API_URL || "",
+  token: env.UPSTASH_REDIS_REST_TOKEN || env.KV_REST_API_TOKEN || ""
 });
 
 export async function GET() {


### PR DESCRIPTION
For Vercel, we should use fromEnv so that we can use env variables `KV_REST_API_URL` and `KV_REST_API_TOKEN`.

see https://github.com/upstash/redis-js/pull/1315