### PR TITLE
Refer to kv env vars in redis examples

### DIFF
--- a/examples/nextjs-with-redis/.env.local.example
+++ b/examples/nextjs-with-redis/.env.local.example
@@ -1,2 +1,6 @@
 UPSTASH_REDIS_REST_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
+
+# If you are using the Vercel & Upstash integration, you may use the following environment variables:
+KV_REST_API_URL=""
+KV_REST_API_TOKEN=""

--- a/examples/nuxt-with-redis/.env.example
+++ b/examples/nuxt-with-redis/.env.example
@@ -1,2 +1,6 @@
 UPSTASH_REDIS_REST_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
+
+# If you are using the Vercel & Upstash integration, you may use the following environment variables:
+KV_REST_API_URL=""
+KV_REST_API_TOKEN=""

--- a/examples/sveltekit-with-redis/.env.example
+++ b/examples/sveltekit-with-redis/.env.example
@@ -1,10 +1,6 @@
-# You must configure one of the following sets:
-# - Both UPSTASH_REDIS_REST_URL & UPSTASH_REDIS_REST_TOKEN
-#   or
-# - Both KV_REST_API_URL & KV_REST_API_TOKEN
-
 UPSTASH_REDIS_REST_URL=""
 UPSTASH_REDIS_REST_TOKEN=""
 
+# If you are using the Vercel & Upstash integration, you may use the following environment variables:
 KV_REST_API_URL=""
 KV_REST_API_TOKEN=""


### PR DESCRIPTION
Adding reference to KV_REST_API_URL and KV_REST_API_TOKEN env variables in the .env.example files of redis examples which are on Vercel templates website